### PR TITLE
fix parsing of "12:** am" time

### DIFF
--- a/projects/mat-timepicker/src/lib/timepicker.directive.ts
+++ b/projects/mat-timepicker/src/lib/timepicker.directive.ts
@@ -275,12 +275,12 @@ export class MatTimepickerDirective implements
 
     if (hours < 12 && meridiem && meridiem.toLowerCase() === 'pm') {
       hours += 12;
-    } else if (hours > 12 && meridiem && meridiem.toLowerCase() === 'am') {
+    } else if (hours >= 12 && meridiem && meridiem.toLowerCase() === 'am') {
       hours -= 12;
     }
 
-    if (this.mode === '12h' && +hours < 1) {
-      hours = '1';
+    if (this.mode === '12h' && +hours < 0) {
+      hours = '0';
     } else {
       if (+hours > 24) {
         hours = '24';


### PR DESCRIPTION
12hr mode was parsed incorrectly, see [issue #40 - Incorrect time parsing](https://github.com/IliaIdakiev/angular-material-timepicker/issues/40)